### PR TITLE
Allow passing listeners into the conductor

### DIFF
--- a/taskflow/conductors/backends/impl_blocking.py
+++ b/taskflow/conductors/backends/impl_blocking.py
@@ -32,10 +32,12 @@ class BlockingConductor(impl_executor.ExecutorConductor):
     def __init__(self, name, jobboard,
                  persistence=None, engine=None,
                  engine_options=None, wait_timeout=None,
-                 log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS):
+                 log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
+                 listener_factories=None):
         super(BlockingConductor, self).__init__(
             name, jobboard,
             persistence=persistence, engine=engine,
             engine_options=engine_options,
             wait_timeout=wait_timeout, log=log,
-            max_simultaneous_jobs=max_simultaneous_jobs)
+            max_simultaneous_jobs=max_simultaneous_jobs,
+            listener_factories=listener_factories)

--- a/taskflow/conductors/backends/impl_executor.py
+++ b/taskflow/conductors/backends/impl_executor.py
@@ -109,10 +109,12 @@ class ExecutorConductor(base.Conductor):
     def __init__(self, name, jobboard,
                  persistence=None, engine=None,
                  engine_options=None, wait_timeout=None,
-                 log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS):
+                 log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
+                 listener_factories=None):
         super(ExecutorConductor, self).__init__(
             name, jobboard, persistence=persistence,
-            engine=engine, engine_options=engine_options)
+            engine=engine, engine_options=engine_options,
+            listener_factories=listener_factories)
         self._wait_timeout = tt.convert_to_timeout(
             value=wait_timeout, default_value=self.WAIT_TIMEOUT,
             event_factory=self._event_factory)
@@ -288,7 +290,8 @@ class ExecutorConductor(base.Conductor):
                     ensure_fresh = False
                 job_it = itertools.takewhile(
                     self._can_claim_more_jobs,
-                    self._jobboard.iterjobs(only_unclaimed=True, ensure_fresh=ensure_fresh))
+                    self._jobboard.iterjobs(only_unclaimed=True,
+                                            ensure_fresh=ensure_fresh))
                 for job in job_it:
                     self._log.debug("Trying to claim job: %s", job)
                     try:

--- a/taskflow/conductors/backends/impl_nonblocking.py
+++ b/taskflow/conductors/backends/impl_nonblocking.py
@@ -54,12 +54,14 @@ class NonBlockingConductor(impl_executor.ExecutorConductor):
                  persistence=None, engine=None,
                  engine_options=None, wait_timeout=None,
                  log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
-                 executor_factory=None):
+                 executor_factory=None,
+                 listener_factories=None):
         super(NonBlockingConductor, self).__init__(
             name, jobboard,
             persistence=persistence, engine=engine,
             engine_options=engine_options, wait_timeout=wait_timeout,
-            log=log, max_simultaneous_jobs=max_simultaneous_jobs)
+            log=log, max_simultaneous_jobs=max_simultaneous_jobs,
+            listener_factories=listener_factories)
         if executor_factory is None:
             self._executor_factory = self._default_executor_factory
         else:


### PR DESCRIPTION
To avoid the awkward need to subclass and override a private method,
you can now pass in listener_factories to any conductor. They will be
used to generate the event listeners on the job objects as jobs are processed.

Fixes #2